### PR TITLE
Apache Cassandra 3.9 on Alpine Linux

### DIFF
--- a/ant/Dockerfile
+++ b/ant/Dockerfile
@@ -1,0 +1,32 @@
+FROM wizdevops/java:8-alpine
+MAINTAINER Minca Daniel Andrei <mandrei17@gmail.com>
+# Metadata params
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.version=$VERSION \
+      org.label-schema.name='Apache Ant on Alpine Linux' \
+      org.label-schema.description='Apache Ant running on Alpine Linux' \
+      org.label-schema.usage='https://github.com/WizDevOps/dockerfiles' \
+      org.label-schema.url='https://github.com/WizDevOps/dockerfiles' \
+      org.label-schema.vendor='Daniel Andrei Minca' \
+      org.label-schema.schema-version='1.0' \
+      org.label-schema.docker.cmd='docker run --rm wizdevops/ant' \
+      org.label-schema.docker.cmd.devel='docker run --rm -ti wizdevops/ant ash' \
+      org.label-schema.docker.debug='docker logs $CONTAINER' \
+      io.github.dminca.docker.dockerfile="/Dockerfile" \
+      io.github.dminca.license="GPLv3"
+# Installs Ant
+ENV ANT_VERSION 1.9.7
+RUN set -x \
+    && cd \
+    && wget -q http://www.us.apache.org/dist/ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && tar -xzf apache-ant-${ANT_VERSION}-bin.tar.gz \
+    && mv apache-ant-${ANT_VERSION} /opt/ant \
+    && rm apache-ant-${ANT_VERSION}-bin.tar.gz
+ENV ANT_HOME /opt/ant
+ENV PATH ${PATH}:/opt/ant/bin

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -1,0 +1,30 @@
+FROM wizdevops/ant
+MAINTAINER Minca Daniel Andrei <mandrei17@gmail.com>
+# Metadata params
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_URL
+ARG VCS_REF
+ENV CASSANDRA_URL="http://apache.javapipe.com/cassandra/3.9/apache-cassandra-3.9-bin.tar.gz"
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.version=$VERSION \
+      org.label-schema.name='Cassandra Docker image' \
+      org.label-schema.description='Cassandra running on Alpine Linux' \
+      org.label-schema.usage='https://github.com/WizDevOps/dockerfiles' \
+      org.label-schema.url='https://github.com/WizDevOps/dockerfiles' \
+      org.label-schema.vendor='Daniel Andrei Minca' \
+      org.label-schema.schema-version='1.0' \
+      org.label-schema.docker.cmd='docker run --rm wizdevops/cassandra' \
+      org.label-schema.docker.cmd.devel='docker run --rm -ti wizdevops/cassandra ash' \
+      org.label-schema.docker.debug='docker logs $CONTAINER' \
+      io.github.dminca.docker.dockerfile="/Dockerfile" \
+      io.github.dminca.license="GPLv3"
+RUN set -x \
+  
+  # download and build
+  && apk add --update git \
+  && mkdir /build \
+  && git clone https://github.com/apache/cassandra.git /build \
+  && cd /build; git checkout cassandra-3.9; ant

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -24,7 +24,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
 RUN set -x \
   
   # download and build
-  && apk add --update git \
+  && apk add --update --no-cache git \
   && mkdir /build \
   && git clone -b cassandra-3.9 https://github.com/apache/cassandra.git /build \
   && cd /build; ant

--- a/cassandra/Dockerfile
+++ b/cassandra/Dockerfile
@@ -26,5 +26,5 @@ RUN set -x \
   # download and build
   && apk add --update git \
   && mkdir /build \
-  && git clone https://github.com/apache/cassandra.git /build \
-  && cd /build; git checkout cassandra-3.9; ant
+  && git clone -b cassandra-3.9 https://github.com/apache/cassandra.git /build \
+  && cd /build; ant

--- a/drupal/alpine/Dockerfile
+++ b/drupal/alpine/Dockerfile
@@ -44,7 +44,7 @@ RUN set -x \
     php7-ssh2 \
     php7-phar \
     php7-zlib \
-    'tar=1.29-r1' \
+    tar=1.29-r1 \
   && rm -rf /var/cache/apk/* \
   && mkdir /tmp/nginx \
   && mkdir -p /var/www/html \

--- a/drupal/alpine/Dockerfile
+++ b/drupal/alpine/Dockerfile
@@ -44,7 +44,7 @@ RUN set -x \
     php7-ssh2 \
     php7-phar \
     php7-zlib \
-    'tar=1.28-r1' --repository http://nl.alpinelinux.org/alpine/v3.3/main \
+    'tar=1.29-r1' \
   && rm -rf /var/cache/apk/* \
   && mkdir /tmp/nginx \
   && mkdir -p /var/www/html \

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -88,7 +88,6 @@ RUN set -x \
            /opt/jdk/jre/lib/amd64/libjavafx*.so \
            /opt/jdk/jre/lib/amd64/libjfx*.so \
            /opt/jdk/jre/lib/ext/jfxrt.jar \
-           /opt/jdk/jre/lib/ext/nashorn.jar \
            /opt/jdk/jre/lib/oblique-fonts \
            /opt/jdk/jre/lib/plugin.jar \
            /tmp/* /var/cache/apk/*

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -25,7 +25,7 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       io.github.dminca.license="GPLv3"
 # Java Version and other ENV
 ENV JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=102 \
+    JAVA_VERSION_MINOR=111 \
     JAVA_VERSION_BUILD=14 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \

--- a/site.yml
+++ b/site.yml
@@ -50,7 +50,7 @@
         - { context: ./drupal/alpine,
             image: "{{ docker_organization }}/drupal",
             tag: 8-alpine,
-            version: 1.2.0 }
+            version: 1.2.1 }
         - { context: ./drupal/debian,
             image: "{{ docker_organization }}/drupal",
             tag: 8-debian,

--- a/site.yml
+++ b/site.yml
@@ -87,7 +87,7 @@
             image: "{{ docker_organization }}/ant",
             tag: latest,
             version: 1.0.0 }
-        - { context: ./cassandra,
-            image: "{{ docker_organization }}/cassandra",
-            tag: latest,
-            version: 3.9 }
+        # - { context: ./cassandra,
+        #     image: "{{ docker_organization }}/cassandra",
+        #     tag: latest,
+        #     version: 3.9 }

--- a/site.yml
+++ b/site.yml
@@ -83,3 +83,11 @@
             image: "{{ docker_organization }}/coffeescript",
             tag: latest,
             version: 1.0.0 }
+        - { context: ./ant,
+            image: "{{ docker_organization }}/ant",
+            tag: latest,
+            version: 1.0.0 }
+        - { context: ./cassandra,
+            image: "{{ docker_organization }}/cassandra",
+            tag: latest,
+            version: 3.9 }

--- a/site.yml
+++ b/site.yml
@@ -62,7 +62,7 @@
         - { context: ./java,
             image: "{{ docker_organization }}/java",
             tag: 8-alpine,
-            version: 1.0.1 }
+            version: 2.0.0 }
         - { context: ./gocd/agent,
             image: "{{ docker_organization }}/gocdagent",
             tag: latest,

--- a/site.yml
+++ b/site.yml
@@ -50,7 +50,7 @@
         - { context: ./drupal/alpine,
             image: "{{ docker_organization }}/drupal",
             tag: 8-alpine,
-            version: 1.1.1 }
+            version: 1.2.0 }
         - { context: ./drupal/debian,
             image: "{{ docker_organization }}/drupal",
             tag: 8-debian,


### PR DESCRIPTION
## Purpose
Create a **Cassandra 3.9** Docker image from base **Alpine Linux**, optional may require building it from source.

### Reference articles
- [Cassandra Package installation directories][1]

[1]: http://docs.datastax.com/en/archived/cassandra/2.0/cassandra/reference/referenceInstallLocatePkg_r.html