### PR TITLE
Refactor Monit Docker image

### DIFF
--- a/monit/Dockerfile
+++ b/monit/Dockerfile
@@ -22,7 +22,7 @@ repair and can execute meaningful causal actions in error situations.' \
       io.github.dminca.docker.dockerfile="/Dockerfile" \
       io.github.dminca.license="GPLv3" \
       MAINTAINER="Minca Daniel Andrei <mandrei17@gmail.com>"
-ENV MONIT_VERSION="5.20.0"
+ENV MONIT_VERSION="5.23.0"
 ENV BUILD_PACKAGES="\
   curl \
   build-base \

--- a/monit/Dockerfile
+++ b/monit/Dockerfile
@@ -23,7 +23,6 @@ repair and can execute meaningful causal actions in error situations.' \
       io.github.dminca.license="GPLv3" \
       MAINTAINER="Minca Daniel Andrei <mandrei17@gmail.com>"
 ENV BUILD_PACKAGES="\
-  dumb-init \
   curl \
   build-base \
   zlib-dev \
@@ -31,7 +30,7 @@ ENV BUILD_PACKAGES="\
   linux-headers"
 
 RUN set -x \
-    && apk add --update --no-cache --virtual build-deps $BUILD_PACKAGES \
+    && apk add --update --no-cache --virtual build-deps $BUILD_PACKAGES dumb-init \
     && curl -o /tmp/monit.tar.gz https://mmonit.com/monit/dist/monit-5.20.0.tar.gz \
     && mkdir -p /etc/monit /tmp/monit-source \
     && tar xf /tmp/monit.tar.gz --strip-components=1 -C /tmp/monit-source \

--- a/monit/Dockerfile
+++ b/monit/Dockerfile
@@ -22,16 +22,18 @@ repair and can execute meaningful causal actions in error situations.' \
       io.github.dminca.docker.dockerfile="/Dockerfile" \
       io.github.dminca.license="GPLv3" \
       MAINTAINER="Minca Daniel Andrei <mandrei17@gmail.com>"
+ENV MONIT_VERSION="5.20.0"
 ENV BUILD_PACKAGES="\
   curl \
   build-base \
   zlib-dev \
   linux-pam-dev \
-  linux-headers"
+  linux-headers" \
+  MONIT_URL="https://mmonit.com/monit/dist/monit-$MONIT_VERSION.tar.gz"
 
 RUN set -x \
     && apk add --update --no-cache --virtual build-deps $BUILD_PACKAGES dumb-init \
-    && curl -o /tmp/monit.tar.gz https://mmonit.com/monit/dist/monit-5.20.0.tar.gz \
+    && curl -o /tmp/monit.tar.gz $MONIT_URL \
     && mkdir -p /etc/monit /tmp/monit-source \
     && tar xf /tmp/monit.tar.gz --strip-components=1 -C /tmp/monit-source \
     && cd /tmp/monit-source; ./configure --without-ssl; cd / \

--- a/monit/Dockerfile
+++ b/monit/Dockerfile
@@ -27,12 +27,14 @@ ENV BUILD_PACKAGES="\
   curl \
   build-base \
   zlib-dev \
-  linux-pam-dev \
   linux-headers" \
   MONIT_URL="https://mmonit.com/monit/dist/monit-$MONIT_VERSION.tar.gz"
 
 RUN set -x \
-    && apk add --update --no-cache --virtual build-deps $BUILD_PACKAGES dumb-init \
+    && apk add --update --no-cache \
+      dumb-init \
+      linux-pam-dev \
+      --virtual build-deps $BUILD_PACKAGES  \
     && curl -o /tmp/monit.tar.gz $MONIT_URL \
     && mkdir -p /etc/monit /tmp/monit-source \
     && tar xf /tmp/monit.tar.gz --strip-components=1 -C /tmp/monit-source \

--- a/monit/Dockerfile
+++ b/monit/Dockerfile
@@ -1,5 +1,4 @@
 FROM wizdevops/alpine
-MAINTAINER Minca Daniel Andrei <mandrei17@gmail.com>
 # Metadata params
 ARG BUILD_DATE
 ARG VERSION
@@ -21,15 +20,18 @@ repair and can execute meaningful causal actions in error situations.' \
       org.label-schema.docker.cmd.devel='docker run --rm -ti wizdevops/monit ash' \
       org.label-schema.docker.debug='docker logs $CONTAINER' \
       io.github.dminca.docker.dockerfile="/Dockerfile" \
-      io.github.dminca.license="GPLv3"
+      io.github.dminca.license="GPLv3" \
+      MAINTAINER="Minca Daniel Andrei <mandrei17@gmail.com>"
+ENV BUILD_PACKAGES="\
+  dumb-init \
+  curl \
+  build-base \
+  zlib-dev \
+  linux-pam-dev \
+  linux-headers"
+
 RUN set -x \
-    && apk add --update --no-cache \
-        dumb-init \
-        curl \
-        build-base \
-        zlib-dev \
-        linux-pam-dev \
-        linux-headers \
+    && apk add --update --no-cache --virtual build-deps $BUILD_PACKAGES \
     && curl -o /tmp/monit.tar.gz https://mmonit.com/monit/dist/monit-5.20.0.tar.gz \
     && mkdir -p /etc/monit /tmp/monit-source \
     && tar xf /tmp/monit.tar.gz --strip-components=1 -C /tmp/monit-source \
@@ -38,11 +40,7 @@ RUN set -x \
     && make install -C /tmp/monit-source/ \
 
       # remove build dependencies
-      && apk del --purge \
-        build-base \
-        zlib-dev \
-        linux-pam-dev \
-        linux-headers \
+      && apk del --purge build-deps \
 
     && cp /tmp/monit-source/monitrc /etc/monit/monitrc-default \
     && cp /tmp/monit-source/monit /etc/monit \

--- a/playbook.yml
+++ b/playbook.yml
@@ -74,7 +74,7 @@
         - { context: ./monit,
             image: "{{ docker_organization }}/monit",
             tag: latest,
-            version: 1.0.0 }
+            version: 2.0.0 }
         - { context: ./golang,
             image: "{{ docker_organization }}/go",
             tag: latest,

--- a/playbook.yml
+++ b/playbook.yml
@@ -74,7 +74,7 @@
         - { context: ./monit,
             image: "{{ docker_organization }}/monit",
             tag: latest,
-            version: 2.0.0 }
+            version: 2.1.0 }
         - { context: ./golang,
             image: "{{ docker_organization }}/go",
             tag: latest,


### PR DESCRIPTION
* remove build dependencies after installation
* split Monit URL and Version into Env Vars so its easier to bump versions and update URL #33 

Closes: #33 