### PR TITLE
bump gocd to v17.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
 
 script:
   - ansible-playbook playbook.yml --syntax-check
-  - travis_wait 60 ansible-playbook playbook.yml
+  - ansible-playbook playbook.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ install:
 
 script:
   - ansible-playbook playbook.yml --syntax-check
-  - ansible-playbook playbook.yml
+  - travis_wait 60 ansible-playbook playbook.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,8 @@ env:
 services:
   - docker
 
-before_install:
-    # Ansible doesn't play well with virtualenv
-  - deactivate
-  - sudo apt-get update -qq
-
 install:
-  - sudo pip install docker-py
-    # software-properties-common for ubuntu 14.04
-    # python-software-properties for ubuntu 12.04
-  - sudo apt-get install -y software-properties-common python-software-properties
-  - sudo apt-add-repository -y ppa:ansible/ansible
-  - sudo apt-get update -qq
-  - sudo apt-get install -y ansible
-  - sudo rm /usr/bin/python && sudo ln -s /usr/bin/python2.7 /usr/bin/python
+  - sudo pip install docker-py ansible
   - ansible --version
   # login docker
   - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"

--- a/gocd/agent/Dockerfile
+++ b/gocd/agent/Dockerfile
@@ -2,11 +2,11 @@ FROM wizdevops/java:8-alpine
 MAINTAINER Daniel Andrei Minca <mandrei17@gmail.com>
 # Metadata params
 ARG BUILD_DATE
-ARG VERSION=${VERSION:-"16.11.0-4185"}
+ARG VERSION=${VERSION:-"17.8.0-5277"}
 ARG VCS_URL
 ARG VCS_REF
-ENV GOCD_VERSION="16.11.0" \
-    SHACHECK="2d1d750be75340a6e87058be91c8a0af2187985bef916d4901b03e06875d5bd1"
+ENV GOCD_VERSION="17.8.0" \
+    SHACHECK="4c9c220240ee42a189c787c1bd967f36c9d2e63f75fb4019f3f3cc409f4db733"
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url=$VCS_URL \
       org.label-schema.vcs-ref=$VCS_REF \

--- a/gocd/agent/Dockerfile
+++ b/gocd/agent/Dockerfile
@@ -26,6 +26,7 @@ RUN set -x \
     && apk add --update --no-cache \
         curl \
         bash \
+        git \
     && curl -sSL https://download.go.cd/binaries/${VERSION}/generic/go-agent-${VERSION}.zip > /tmp/go-agent-${VERSION}.zip \
     && mkdir /etc/go-agent \
     && unzip /tmp/go-agent-${VERSION}.zip -d /tmp \

--- a/gocd/agent/Dockerfile
+++ b/gocd/agent/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG VCS_URL
 ARG VCS_REF
-ENV GOCD_VERSION=${VERSION:0:6} \
+ENV GOCD_VERSION="17.8.0-5277" \
     SHACHECK="4c9c220240ee42a189c787c1bd967f36c9d2e63f75fb4019f3f3cc409f4db733"
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url=$VCS_URL \
@@ -27,10 +27,10 @@ RUN set -x \
         curl \
         bash \
         git \
-    && curl -sSL -o /tmp/go-agent.zip https://download.go.cd/binaries/${VERSION}/generic/go-agent-${VERSION}.zip \
+    && curl -sSL -o /tmp/go-agent.zip https://download.go.cd/binaries/${GOCD_VERSION}/generic/go-agent-${GOCD_VERSION}.zip \
     && mkdir /etc/go-agent \
     && unzip /tmp/go-agent.zip -d /tmp \
     && cd /tmp; echo "${SHACHECK}  go-agent.zip" | sha256sum -c - | grep OK; cd - \
-    && cp -vr /tmp/go-agent-${GOCD_VERSION}/* /etc/go-agent \
+    && cp -vr /tmp/go-agent-${GOCD_VERSION:0:6}/* /etc/go-agent \
     && rm -rfv /tmp/*
 CMD ["/etc/go-agent/agent.sh"]

--- a/gocd/agent/Dockerfile
+++ b/gocd/agent/Dockerfile
@@ -2,10 +2,10 @@ FROM wizdevops/java:8-alpine
 MAINTAINER Daniel Andrei Minca <mandrei17@gmail.com>
 # Metadata params
 ARG BUILD_DATE
-ARG VERSION=${VERSION:-"17.8.0-5277"}
+ARG VERSION
 ARG VCS_URL
 ARG VCS_REF
-ENV GOCD_VERSION="17.8.0" \
+ENV GOCD_VERSION=${VERSION:0:6} \
     SHACHECK="4c9c220240ee42a189c787c1bd967f36c9d2e63f75fb4019f3f3cc409f4db733"
 LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.vcs-url=$VCS_URL \
@@ -27,12 +27,10 @@ RUN set -x \
         curl \
         bash \
         git \
-    && cd /tmp;\
-      curl -sSLO https://download.go.cd/binaries/${VERSION}/generic/go-agent-${VERSION}.zip;\
-      cd - \
+    && curl -sSL -o /tmp/go-agent.zip https://download.go.cd/binaries/${VERSION}/generic/go-agent-${VERSION}.zip \
     && mkdir /etc/go-agent \
-    && unzip /tmp/go-agent-${VERSION}.zip -d /tmp \
-    && cd /tmp; echo "${SHACHECK}  go-agent-${VERSION}.zip" | sha256sum -c - | grep OK; cd / \
+    && unzip /tmp/go-agent.zip -d /tmp \
+    && cd /tmp; echo "${SHACHECK}  go-agent.zip" | sha256sum -c - | grep OK; cd - \
     && cp -vr /tmp/go-agent-${GOCD_VERSION}/* /etc/go-agent \
     && rm -rfv /tmp/*
 CMD ["/etc/go-agent/agent.sh"]

--- a/gocd/agent/Dockerfile
+++ b/gocd/agent/Dockerfile
@@ -27,7 +27,9 @@ RUN set -x \
         curl \
         bash \
         git \
-    && curl -sSL https://download.go.cd/binaries/${VERSION}/generic/go-agent-${VERSION}.zip > /tmp/go-agent-${VERSION}.zip \
+    && cd /tmp;\
+      curl -sSLO https://download.go.cd/binaries/${VERSION}/generic/go-agent-${VERSION}.zip;\
+      cd - \
     && mkdir /etc/go-agent \
     && unzip /tmp/go-agent-${VERSION}.zip -d /tmp \
     && cd /tmp; echo "${SHACHECK}  go-agent-${VERSION}.zip" | sha256sum -c - | grep OK; cd / \

--- a/gocd/server/Dockerfile
+++ b/gocd/server/Dockerfile
@@ -2,10 +2,10 @@ FROM wizdevops/java:8-alpine
 MAINTAINER Daniel Andrei Minca <mandrei17@gmail.com>
 # Metadata params
 ARG BUILD_DATE
-ARG VERSION=${VERSION:-"17.8.0-5277"}
+ARG VERSION
 ARG VCS_URL
 ARG VCS_REF
-ENV GOCD_VERSION="17.8.0" \
+ENV GOCD_VERSION=${VERSION:0:6} \
     SHACHECK="6764cd8c3f13824f892140464d1d50b753d9c1f3782ae38586303d59e296294e" \
     AGPORT=8154 \
     SRVPORT=8153
@@ -29,12 +29,10 @@ RUN set -x \
         curl \
         bash \
         git \
-    && cd /tmp;\
-      curl -sSLO https://download.go.cd/binaries/${VERSION}/generic/go-server-${VERSION}.zip;\
-      cd - \
+    && curl -sSL -o /tmp/go-server.zip https://download.go.cd/binaries/${VERSION}/generic/go-server-${VERSION}.zip \
     && mkdir /etc/go-server \
-    && unzip /tmp/go-server-${VERSION}.zip -d /tmp \
-    && cd /tmp; echo "${SHACHECK}  go-server-${VERSION}.zip" | sha256sum -c - | grep OK; cd /\
+    && unzip /tmp/go-server.zip -d /tmp \
+    && cd /tmp; echo "${SHACHECK}  go-server.zip" | sha256sum -c - | grep OK; cd /\
     && cp -vr /tmp/go-server-${GOCD_VERSION}/* /etc/go-server \
     && rm -rfv /tmp/*
 EXPOSE ${AGPORT} ${SRVPORT}

--- a/gocd/server/Dockerfile
+++ b/gocd/server/Dockerfile
@@ -2,11 +2,11 @@ FROM wizdevops/java:8-alpine
 MAINTAINER Daniel Andrei Minca <mandrei17@gmail.com>
 # Metadata params
 ARG BUILD_DATE
-ARG VERSION=${VERSION:-"16.11.0-4185"}
+ARG VERSION=${VERSION:-"17.8.0-5277"}
 ARG VCS_URL
 ARG VCS_REF
-ENV GOCD_VERSION="16.11.0" \
-    SHACHECK="c8fa2dc52dd4797d8f2aa85823f8896dc4d89ee77b3b23925c93afd885080875" \
+ENV GOCD_VERSION="17.8.0" \
+    SHACHECK="6764cd8c3f13824f892140464d1d50b753d9c1f3782ae38586303d59e296294e" \
     AGPORT=8154 \
     SRVPORT=8153
 LABEL org.label-schema.build-date=$BUILD_DATE \
@@ -31,7 +31,7 @@ RUN set -x \
     && curl -sSL https://download.go.cd/binaries/${VERSION}/generic/go-server-${VERSION}.zip > /tmp/go-server-${VERSION}.zip \
     && mkdir /etc/go-server \
     && unzip /tmp/go-server-${VERSION}.zip -d /tmp \
-    && cd /tmp; echo "${SHACHECK}  go-server-16.11.0-4185.zip" | sha256sum -c - | grep OK; cd /\
+    && cd /tmp; echo "${SHACHECK}  go-server-${VERSION}.zip" | sha256sum -c - | grep OK; cd /\
     && cp -vr /tmp/go-server-${GOCD_VERSION}/* /etc/go-server \
     && rm -rfv /tmp/*
 EXPOSE ${AGPORT} ${SRVPORT}

--- a/gocd/server/Dockerfile
+++ b/gocd/server/Dockerfile
@@ -28,6 +28,7 @@ RUN set -x \
     && apk add --update --no-cache \
         curl \
         bash \
+        git \
     && curl -sSL https://download.go.cd/binaries/${VERSION}/generic/go-server-${VERSION}.zip > /tmp/go-server-${VERSION}.zip \
     && mkdir /etc/go-server \
     && unzip /tmp/go-server-${VERSION}.zip -d /tmp \

--- a/gocd/server/Dockerfile
+++ b/gocd/server/Dockerfile
@@ -5,7 +5,7 @@ ARG BUILD_DATE
 ARG VERSION
 ARG VCS_URL
 ARG VCS_REF
-ENV GOCD_VERSION=${VERSION:0:6} \
+ENV GOCD_VERSION="17.8.0-5277" \
     SHACHECK="6764cd8c3f13824f892140464d1d50b753d9c1f3782ae38586303d59e296294e" \
     AGPORT=8154 \
     SRVPORT=8153
@@ -29,11 +29,11 @@ RUN set -x \
         curl \
         bash \
         git \
-    && curl -sSL -o /tmp/go-server.zip https://download.go.cd/binaries/${VERSION}/generic/go-server-${VERSION}.zip \
+    && curl -sSL -o /tmp/go-server.zip https://download.go.cd/binaries/${GOCD_VERSION}/generic/go-server-${GOCD_VERSION}.zip \
     && mkdir /etc/go-server \
     && unzip /tmp/go-server.zip -d /tmp \
     && cd /tmp; echo "${SHACHECK}  go-server.zip" | sha256sum -c - | grep OK; cd /\
-    && cp -vr /tmp/go-server-${GOCD_VERSION}/* /etc/go-server \
+    && cp -vr /tmp/go-server-${GOCD_VERSION:0:6}/* /etc/go-server \
     && rm -rfv /tmp/*
 EXPOSE ${AGPORT} ${SRVPORT}
 CMD ["/etc/go-server/server.sh"]

--- a/gocd/server/Dockerfile
+++ b/gocd/server/Dockerfile
@@ -29,7 +29,9 @@ RUN set -x \
         curl \
         bash \
         git \
-    && curl -sSL https://download.go.cd/binaries/${VERSION}/generic/go-server-${VERSION}.zip > /tmp/go-server-${VERSION}.zip \
+    && cd /tmp;\
+      curl -sSLO https://download.go.cd/binaries/${VERSION}/generic/go-server-${VERSION}.zip;\
+      cd - \
     && mkdir /etc/go-server \
     && unzip /tmp/go-server-${VERSION}.zip -d /tmp \
     && cd /tmp; echo "${SHACHECK}  go-server-${VERSION}.zip" | sha256sum -c - | grep OK; cd /\

--- a/java/Dockerfile
+++ b/java/Dockerfile
@@ -25,8 +25,8 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       io.github.dminca.license="GPLv3"
 # Java Version and other ENV
 ENV JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=131 \
-    JAVA_VERSION_BUILD=11 \
+    JAVA_VERSION_MINOR=144 \
+    JAVA_VERSION_BUILD=01 \
     JAVA_PACKAGE=jdk \
     JAVA_JCE=standard \
     JAVA_HOME=/opt/jdk \
@@ -44,7 +44,7 @@ RUN set -x \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
     mkdir /opt && \
     curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
-      http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/d54c1d3a095b4ff2b6607d096fa80163/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
+      http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/090f390dda5b47b9b721c7dfaa008135/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
     ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} /opt/jdk && \

--- a/monit/Dockerfile
+++ b/monit/Dockerfile
@@ -22,6 +22,7 @@ repair and can execute meaningful causal actions in error situations.' \
       org.label-schema.docker.debug='docker logs $CONTAINER' \
       io.github.dminca.docker.dockerfile="/Dockerfile" \
       io.github.dminca.license="GPLv3"
+ENV MONIT_VERSION='5.23.0'
 RUN set -x \
     && apk add --update --no-cache \
         dumb-init \
@@ -30,7 +31,7 @@ RUN set -x \
         zlib-dev \
         linux-pam-dev \
         linux-headers \
-    && curl -o /tmp/monit.tar.gz https://mmonit.com/monit/dist/monit-5.20.0.tar.gz \
+    && curl -o /tmp/monit.tar.gz https://mmonit.com/monit/dist/monit-${MONIT_VERSION}.tar.gz \
     && mkdir -p /etc/monit /tmp/monit-source \
     && tar xf /tmp/monit.tar.gz --strip-components=1 -C /tmp/monit-source \
     && cd /tmp/monit-source; ./configure --without-ssl; cd / \

--- a/playbook.yml
+++ b/playbook.yml
@@ -92,23 +92,3 @@
             tag: latest,
             version: 1.1.0 }
 
-    - name: cleanup after build
-      docker_image:
-        name: "{{ docker_organization }}"
-        tag: "{{ item }}"
-        force: true
-        state: absent
-      with_items:
-        - alpine
-        - python
-        - drupal
-        - packer
-        - java
-        - gocdagent
-        - gocdserver
-        - monit
-        - go
-        - coffeescript
-        - ansible
-        - alpine-mysql
-

--- a/playbook.yml
+++ b/playbook.yml
@@ -66,11 +66,11 @@
         - { context: ./gocd/agent,
             image: "{{ docker_organization }}/gocdagent",
             tag: latest,
-            version: 17.8.0-5277 }
+            version: 2.0.0 }
         - { context: ./gocd/server,
             image: "{{ docker_organization }}/gocdserver",
             tag: latest,
-            version: 17.8.0-5277 }
+            version: 2.0.0 }
         - { context: ./monit,
             image: "{{ docker_organization }}/monit",
             tag: latest,

--- a/playbook.yml
+++ b/playbook.yml
@@ -66,11 +66,11 @@
         - { context: ./gocd/agent,
             image: "{{ docker_organization }}/gocdagent",
             tag: latest,
-            version: 16.11.0-4185 }
+            version: 17.8.0-5277 }
         - { context: ./gocd/server,
             image: "{{ docker_organization }}/gocdserver",
             tag: latest,
-            version: 16.11.0-4185 }
+            version: 17.8.0-5277 }
         - { context: ./monit,
             image: "{{ docker_organization }}/monit",
             tag: latest,


### PR DESCRIPTION
* update SHA256 for both Agent and Server
* update version and build number
* refactor Go Server SHA256 Check to use already created variable in
  order instead of hardcoded version

Resolves:
Related:
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>